### PR TITLE
fix(db): Rename the local variable to erase the conflict with a global

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -136,7 +136,7 @@ test('generateContext returns context with correct dhex colors', function(t) {
 
 test('buildTemplate returns correct result', function(t) {
   // buildTheme usually takes file contents. Emulate that by converting scheme to a string.
-  const scheme = JSON.stringify(scheme);
+  const localScheme = JSON.stringify(scheme);
 
   const template = `
     {{ scheme }}
@@ -180,7 +180,7 @@ test('buildTemplate returns correct result', function(t) {
     AB7967
   `;
 
-  const actual = buildTheme(scheme, template);
+  const actual = buildTheme(localScheme, template);
 
   t.is(actual, expected);
 });


### PR DESCRIPTION
I think that the local scheme has a conflit with the global scheme. So I rename it and it works.

related to #34